### PR TITLE
refactor - UITapGestureRecognizer to disable prior to start game

### DIFF
--- a/CopyCat/GameViewController.swift
+++ b/CopyCat/GameViewController.swift
@@ -42,13 +42,6 @@ class GameViewController: UIViewController {
         
         catImageViews =  [cat1, cat2, cat3, cat4]
         
-        for (index, catImageView) in catImageViews.enumerated() {
-            catImageView.isUserInteractionEnabled = true
-            catImageView.tag = index
-            let tap = UITapGestureRecognizer(target: self, action: #selector(catTapped(_:)))
-            catImageView.addGestureRecognizer(tap)
-        }
-        
         game.resetGame()
         configure(with: game)
     }
@@ -105,6 +98,12 @@ class GameViewController: UIViewController {
     @IBAction func didPressPlay(_ sender: UIButton) {
         sender.isHidden = true
         createCatSequence()
+        for (index, catImageView) in catImageViews.enumerated() {
+            catImageView.isUserInteractionEnabled = true
+            catImageView.tag = index
+            let tap = UITapGestureRecognizer(target: self, action: #selector(catTapped(_:)))
+            catImageView.addGestureRecognizer(tap)
+        }
     }
     
     


### PR DESCRIPTION
Description:  Current placement of UITapGestureRecognizer enabled recognizing a cat tap before the game started, causing a crash in the catTapped function where we compare userTap to cat sequence.

Incorrect:
<img width="1062" alt="Screenshot 2025-04-22 at 12 01 39" src="https://github.com/user-attachments/assets/c5d71904-9371-4659-beba-4ccd968aad38" />

https://github.com/user-attachments/assets/a1c4103a-ac23-42b0-bbab-c92e4ed94ae9


Summary of Changes: 
- [ ] Moved  TapGestureRecognizer from viewDidLoad to didPressPlay to disable recognizing a cat tap prior to starting a game.

https://github.com/user-attachments/assets/eb90c825-3498-403e-b3d9-f4439a08802d 

